### PR TITLE
fix #6 compatibility with psr 1.2.0

### DIFF
--- a/tests/Factory/createUploadedFile_err01.phpt
+++ b/tests/Factory/createUploadedFile_err01.phpt
@@ -43,8 +43,8 @@ try {
 
 ?>
 --EXPECTF--
-%sttpMessage\Factory::createUploadedFile()%s Psr\Http\Message\StreamInterface, string given
-%sttpMessage\Factory::createUploadedFile()%s Psr\Http\Message\StreamInterface,%sstdClass given
+%sttpMessage\Factory::createUploadedFile()%s\Http\Message\StreamInterface, string given
+%sttpMessage\Factory::createUploadedFile()%s\Http\Message\StreamInterface,%sstdClass given
 %sttpMessage\Factory::createUploadedFile()%s, array given
 %sttpMessage\Factory::createUploadedFile()%sint, array given
 %sttpMessage\Factory::createUploadedFile()%s, array given

--- a/tests/Message/body_err01.phpt
+++ b/tests/Message/body_err01.phpt
@@ -19,5 +19,5 @@ try {
 
 ?>
 --EXPECTF--
-%sttpMessage\Message::withBody()%s Psr\Http\Message\StreamInterface, resource given
+%sttpMessage\Message::withBody()%s\Http\Message\StreamInterface, resource given
 HttpMessage\Message::withBody() expects exactly 1 %s, 0 given

--- a/tests/Request/uri_err01.phpt
+++ b/tests/Request/uri_err01.phpt
@@ -19,4 +19,4 @@ try {
 ?>
 --EXPECTF--
 HttpMessage\Request::withUri() expects exactly 1 %s, 0 given
-%sttpMessage\Request::withUri()%sPsr\Http\Message\UriInterface, string given
+%sttpMessage\Request::withUri()%s\Http\Message\UriInterface, string given

--- a/uri.c
+++ b/uri.c
@@ -113,8 +113,11 @@ PHP_METHOD(Uri, __construct)
 
 
 /* __toString */
-
+#if PHP_VERSION_ID >= 80000 && PHP_PSR_VERSION_ID >= 10200
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_HttpMessageUri_toString, 0, 0, IS_STRING, 0)
+#else
 ZEND_BEGIN_ARG_INFO_EX(arginfo_HttpMessageUri_toString, 0, 0, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 PHP_METHOD(Uri, __toString)


### PR DESCRIPTION
Using php 8.0.13 and psr 1.2.0

```
=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :    0
Exts tested     :   17
---------------------------------------------------------------------

Number of tests :  196               196
Tests skipped   :    0 (  0.0%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    0 (  0.0%) (  0.0%)
Tests passed    :  196 (100.0%) (100.0%)
---------------------------------------------------------------------
Time taken      :    1 seconds
=====================================================================

```